### PR TITLE
Force Scala Macros usage to generate TypeInformation

### DIFF
--- a/src/main/scala/eu/proteus/solma/fd/FrequentDirections.scala
+++ b/src/main/scala/eu/proteus/solma/fd/FrequentDirections.scala
@@ -97,7 +97,7 @@ object FrequentDirections {
 
   var ell, d: Int = -1
 
-  implicit def treansformFrequentDirections[T <: Vector : TypeInformation] = {
+  implicit def treansformFrequentDirections[T <: Vector : TypeInformation : ClassTag] = {
     new TransformDataStreamOperation[FrequentDirections, T, T] {
       override def transformDataStream(
           instance: FrequentDirections,

--- a/src/main/scala/eu/proteus/solma/moments/MomentsEstimator.scala
+++ b/src/main/scala/eu/proteus/solma/moments/MomentsEstimator.scala
@@ -29,6 +29,7 @@ import eu.proteus.solma.pipeline.StreamEstimator.PartitioningOperation
 import org.apache.flink.api.common.typeinfo.TypeInformation
 
 import scala.collection.mutable
+import scala.reflect.ClassTag
 
 /**
   * A simple stream transformer that ingests a stream of samples and outputs
@@ -157,7 +158,7 @@ object MomentsEstimator {
     }
   }
 
-  implicit def transformMomentsEstimators[E <: StreamEvent] = {
+  implicit def transformMomentsEstimators[E <: StreamEvent : TypeInformation : ClassTag] = {
     new TransformDataStreamOperation[MomentsEstimator, E, (Long, Moments)]{
       override def transformDataStream(
         instance: MomentsEstimator,

--- a/src/main/scala/eu/proteus/solma/package.scala
+++ b/src/main/scala/eu/proteus/solma/package.scala
@@ -20,11 +20,13 @@ import org.apache.flink.api.common.functions.FoldFunction
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.scala._
 
+import scala.reflect.ClassTag
+
 package object solma {
 
-  implicit class RichDataStream[T](dataStream: DataStream[T]) {
+  implicit class RichDataStream[T : TypeInformation : ClassTag](dataStream: DataStream[T]) {
 
-    def fold[R: TypeInformation](zeroValue: R)(fun: (R, T) => R): DataStream[R] = {
+    def fold[R : TypeInformation : ClassTag](zeroValue: R)(fun: (R, T) => R): DataStream[R] = {
       implicit val typeInfo = createTypeInformation[(Int, T)]
 
       val folder = new FoldFunction[(Int, T), R] {

--- a/src/main/scala/eu/proteus/solma/package.scala
+++ b/src/main/scala/eu/proteus/solma/package.scala
@@ -25,7 +25,7 @@ package object solma {
   implicit class RichDataStream[T](dataStream: DataStream[T]) {
 
     def fold[R: TypeInformation](zeroValue: R)(fun: (R, T) => R): DataStream[R] = {
-      implicit val typeInfo = TypeInformation.of(classOf[(Int, T)])
+      implicit val typeInfo = createTypeInformation[(Int, T)]
 
       val folder = new FoldFunction[(Int, T), R] {
         def fold(acc: R, v: (Int, T)) = {

--- a/src/main/scala/eu/proteus/solma/sampling/SimpleReservoirSampling.scala
+++ b/src/main/scala/eu/proteus/solma/sampling/SimpleReservoirSampling.scala
@@ -26,7 +26,7 @@ import eu.proteus.solma.pipeline.StreamFitOperation
 import eu.proteus.solma.pipeline.StreamTransformer
 import eu.proteus.solma.pipeline.TransformDataStreamOperation
 import eu.proteus.solma.utils.FlinkSolmaUtils
-import org.apache.flink.streaming.api.scala.DataStream
+import org.apache.flink.streaming.api.scala._
 import org.apache.flink.util.XORShiftRandom
 
 import scala.collection.mutable
@@ -83,7 +83,7 @@ object SimpleReservoirSampling {
           resultingParameters.get(PartitioningOperation))
         val k = resultingParameters(ReservoirSize)
         val gen = new XORShiftRandom()
-        implicit val typeInfo = TypeInformation.of(classOf[(Long, Array[T])])
+        implicit val typeInfo = createTypeInformation[(Long, Array[T])]
         statefulStream.flatMapWithState((in, state: Option[(Long, Array[T])]) => {
           val (element, _) = in
           state match {

--- a/src/main/scala/eu/proteus/solma/sax/SAX.scala
+++ b/src/main/scala/eu/proteus/solma/sax/SAX.scala
@@ -113,7 +113,7 @@ object SAX {
 
     input match {
       case tuples : DataStream[(T, Int)] => {
-        implicit val typeInfo = TypeInformation.of(classOf[(Any, Int)])
+        implicit val typeInfo = createTypeInformation[(Any, Int)]
         tuples.asInstanceOf[DataStream[(T, Int)]].keyBy(t => t._2)
       }
       case _ => {

--- a/src/main/scala/eu/proteus/solma/utils/FlinkSolmaUtils.scala
+++ b/src/main/scala/eu/proteus/solma/utils/FlinkSolmaUtils.scala
@@ -21,6 +21,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.scala._
 import org.apache.flink.util.XORShiftRandom
 
+import scala.reflect.ClassTag
+
 @Proteus
 object FlinkSolmaUtils {
   def registerFlinkMLTypes(env: StreamExecutionEnvironment): Unit = {
@@ -54,7 +56,7 @@ object FlinkSolmaUtils {
 
   }
 
-  def ensureKeyedStream[T](
+  def ensureKeyedStream[T : TypeInformation : ClassTag](
       input: DataStream[T],
       funOpt: Option[(DataStream[Any]) => KeyedStream[(Any, Long), Long]]
     ): KeyedStream[(T, Long), Long] = {

--- a/src/main/scala/eu/proteus/solma/utils/FlinkSolmaUtils.scala
+++ b/src/main/scala/eu/proteus/solma/utils/FlinkSolmaUtils.scala
@@ -68,7 +68,7 @@ object FlinkSolmaUtils {
           case None => {
             val gen = new XORShiftRandom()
             val max = input.executionEnvironment.getParallelism
-            implicit val typeInfo = TypeInformation.of(classOf[(T, Long)])
+            implicit val typeInfo = createTypeInformation[(T, Long)]
             input
               .map(x => (x, gen.nextInt(max).toLong))
               .keyBy(x => x._2)

--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -105,6 +105,7 @@
  <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
   <parameters>
    <parameter name="regex"><![CDATA[println]]></parameter>
+   <parameter name="regex"><![CDATA[TypeInformation.of]]></parameter>
   </parameters>
  </check>
  <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">


### PR DESCRIPTION
This PR aims to enforce the usage of createTypeInformation[...] macro instead of using TypeInformation.of(classOf[...]) java method.