### PR TITLE
Add Online Support Vector Machine for Binary Classification

### DIFF
--- a/src/main/scala/eu/proteus/solma/osvm/OSVM.scala
+++ b/src/main/scala/eu/proteus/solma/osvm/OSVM.scala
@@ -1,0 +1,219 @@
+/*
+ * Copyright (C) 2017 The Proteus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.proteus.solma.osvm
+
+import breeze.linalg.{DenseMatrix, DenseVector, Vector}
+import eu.proteus.annotations.Proteus
+import eu.proteus.solma.events.{StreamEvent, StreamEventLabel, StreamEventWithPos}
+import eu.proteus.solma.pipeline.StreamTransformer
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.ml.common.{Parameter, WithParameters}
+import org.slf4j.Logger
+
+import scala.reflect.ClassTag
+
+@Proteus
+class OSVM extends StreamTransformer[OSVM]{
+
+  import eu.proteus.solma.osvm.OSVM._
+
+  /** Get the WorkerParallism value as Int
+    * @return The number of worker parallelism
+    */
+  def getWorkerParallelism() : Int  = {
+    this.parameters.get(OSVM.WorkerParallism).get
+  }
+
+  /**
+    * Set the WorkerParallelism value as Int
+    * @param workerParallism workerParallism as Int
+    * @return
+    */
+  def setWorkerParallelism(workerParallism : Int): OSVM = {
+    this.parameters.add(WorkerParallism, workerParallism)
+    this
+  }
+  /**
+    * Get the SeverParallism value as Int
+    * @return The number of server parallelism
+    */
+  def getPSParallelism() : Int  = {
+    this.parameters.get(PSParallelism).get
+  }
+  /**
+    * Set the SeverParallism value as Int
+    * @param psParallelism serverparallelism as Int
+    * @return
+    */
+  def setPSParallelism(psParallelism : Int): OSVM = {
+    parameters.add(PSParallelism, psParallelism)
+    this
+  }
+  /**
+    * Variable to stop the calculation in stream environment
+    * @param iterationWaitTime time as ms (long)
+    * @return
+    */
+  def setIterationWaitTime(iterationWaitTime: Long) : OSVM = {
+    parameters.add(IterationWaitTime, iterationWaitTime)
+    this
+  }
+  /** Variable to stop the calculation in stream environment
+    * get the waiting time
+    * @return The waiting time as Long
+    */
+  def getIterationWaitTime() : Long  = {
+    this.parameters.get(IterationWaitTime).get
+  }
+
+  /**
+    * set a pull limit
+    * @param pullLimit
+    */
+  def setPullLimit(pullLimit : Int) : OSVM = {
+    this.parameters.add(PullLimit, pullLimit)
+    this
+  }
+  /**
+    * Get the pull limit
+    * @return The pull limit
+    */
+  def getPullLimit(): Int = {
+    this.parameters.get(PullLimit).get
+  }
+
+  /**
+    * set allowed lateness
+    * @param allowedLateness
+    */
+  def setAllowedLateness(allowedLateness: Int) : OSVM = {
+    this.parameters.add(AllowedLateness, allowedLateness)
+    this
+  }
+  /**
+    * Get the allowed lateness
+    * @return The allowed lateness
+    */
+  def getAllowedLateness(): Int = {
+    this.parameters.get(AllowedLateness).get
+  }
+
+   /**
+    * set a pull
+    * @param featuresCount
+    */
+  def setFeaturesCount(featuresCount: Int) : OSVM = {
+    this.parameters.add(FeaturesCount, featuresCount)
+    this
+  }
+  /**
+    * Get the Windowsize
+    * @return The windowsize
+    */
+  def getFeaturesCount(): Int = {
+    this.parameters.get(FeaturesCount).get
+  }
+
+}
+
+object OSVM extends WithParameters with Serializable {
+
+  type OSVMStreamEvent = Either[(Long, StreamEvent), Label]
+  type OSVMModel = (DenseVector[Double], Double)
+  type UnlabeledVector = Vector[Double]
+  type Label = (Long, Double)
+
+  /**
+    * Apply helper.
+    * @return A new [[OSVM]].
+    */
+  def apply(): OSVM = {
+    new OSVM()
+  }
+
+  /**
+    * Class logger.
+    */
+  private val Log: Logger = org.slf4j.LoggerFactory.getLogger(this.getClass.getName)
+
+  case object IterationWaitTime extends Parameter[Long] {
+    /**
+      * Default time - needs to be set in any case to stop this calculation
+      */
+    private val DefaultIterationWaitTime: Long = 4000
+    /**
+      * Default value.
+      */
+    override val defaultValue: Option[Long] = Some(IterationWaitTime.DefaultIterationWaitTime)
+  }
+  case object WorkerParallism extends Parameter[Int] {
+    /**
+      * Default parallelism
+      */
+    private val DefaultWorkerParallism: Int = 4
+    /**
+      * Default value.
+      */
+    override val defaultValue: Option[Int] = Some(WorkerParallism.DefaultWorkerParallism)
+  }
+  case object PullLimit extends Parameter[Int] {
+    /**
+      * Default parallelism
+      */
+    private val DefaultPullLimit: Int = 20000
+    /**
+      * Default value.
+      */
+    override val defaultValue: Option[Int] = Some(PullLimit.DefaultPullLimit)
+  }
+  case object PSParallelism extends Parameter[Int] {
+    /**
+      * Default server parallelism.
+      */
+    private val DefaultPSParallelism: Int = 4
+    /**
+      * Default value.
+      */
+    override val defaultValue: Option[Int] = Some(PSParallelism.DefaultPSParallelism)
+  }
+  case object AllowedLateness extends Parameter[Int] {
+    /**
+      * Default Label for unseen data
+      */
+    private val AllowedLatenessDefault: Int = 1
+    /**
+      * Default value.
+      */
+    override val defaultValue: Option[Int] = Some(AllowedLateness.AllowedLatenessDefault)
+  }
+  case object FeaturesCount extends Parameter[Int] {
+    /**
+      * Default output are the Weights
+      */
+    private val DefaultFeaturesCount: Int = -1
+    /**
+      * Default value.
+      */
+    override val defaultValue: Option[Int] = Some(FeaturesCount.DefaultFeaturesCount)
+  }
+
+  implicit def transformStreamImplementation = {
+    new OSVMPrequentialTraining
+  }
+
+
+}

--- a/src/main/scala/eu/proteus/solma/osvm/OSVMPrequentialTraining.scala
+++ b/src/main/scala/eu/proteus/solma/osvm/OSVMPrequentialTraining.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2017 The Proteus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.proteus.solma.osvm
+
+import org.apache.flink.ml.common.ParameterMap
+import org.apache.flink.streaming.api.scala._
+import breeze.linalg.{DenseMatrix, DenseVector, diag}
+import eu.proteus.annotations.Proteus
+import eu.proteus.solma.osvm.OSVM.OSVMStreamEvent
+import eu.proteus.solma.osvm.algorithm.OSVMAlgorithm
+import eu.proteus.solma.pipeline.TransformDataStreamOperation
+import hu.sztaki.ilab.ps.entities.{PSToWorker, Pull, Push, WorkerToPS}
+import hu.sztaki.ilab.ps.server.RangePSLogicWithClose
+import hu.sztaki.ilab.ps.{FlinkParameterServer, WorkerLogic}
+import org.apache.flink.util.XORShiftRandom
+
+@Proteus
+class OSVMPrequentialTraining extends TransformDataStreamOperation[
+      OSVM,
+      OSVM.OSVMStreamEvent,
+      Either[(OSVM.UnlabeledVector, Double), (Int, OSVM.OSVMModel)]] {
+
+
+   def init(n : Int, bias: Double): Int => OSVM.OSVMModel =
+    _ => (DenseVector.rand(n), bias)
+
+  def rangePartitionerPS[P](featureCount: Int)(psParallelism: Int): (WorkerToPS[P]) => Int = {
+    val partitionSize = Math.ceil(featureCount.toDouble / psParallelism).toInt
+    val partitonerFunction = (paramId: Int) => Math.abs(paramId) / partitionSize
+
+    val paramPartitioner: WorkerToPS[P] => Int = {
+      case WorkerToPS(_, msg) => msg match {
+        case Left(Pull(paramId)) => partitonerFunction(paramId)
+        case Right(Push(paramId, _)) => partitonerFunction(paramId)
+      }
+    }
+
+    paramPartitioner
+  }
+
+  override def transformDataStream(
+      instance: OSVM,
+      transformParameters: ParameterMap,
+      input: DataStream[OSVMStreamEvent]
+  ): DataStream[Either[(OSVM.UnlabeledVector, Double), (Int, OSVM.OSVMModel)]] = {
+
+    val workerParallelism: Int = instance.getWorkerParallelism
+    val psParallelism: Int  = instance.getPSParallelism
+    val pullLimit: Int  = instance.getPullLimit
+    val featureCount: Int  = instance.getFeaturesCount
+    val iterationWaitTime: Long  = instance.getIterationWaitTime
+    val allowedLateness: Long  = instance.getAllowedLateness
+
+    val updater = (currModel: OSVM.OSVMModel, gradient: OSVM.OSVMModel) => {
+      (currModel._1 - gradient._1, currModel._2 - gradient._2)
+    }
+
+    val rnd = new XORShiftRandom()
+
+    val initializer = init(featureCount, rnd.nextDouble())
+
+    val workerLogic =  WorkerLogic.addPullLimiter(
+      new OSVMWorkerLogic(
+        new OSVMAlgorithm(instance)),
+    pullLimit)
+
+    val serverLogic = new RangePSLogicWithClose[OSVM.OSVMModel](featureCount, initializer, updater)
+    val paramPartitioner: WorkerToPS[OSVM.OSVMModel] => Int = rangePartitionerPS(featureCount)(psParallelism)
+
+    val wInPartition: PSToWorker[OSVM.OSVMModel] => Int = {
+      case PSToWorker(workerPartitionIndex, _) => workerPartitionIndex
+    }
+
+    implicit val inputTypeInfo = createTypeInformation[OSVMStreamEvent]
+    FlinkParameterServer.transform(input, workerLogic, serverLogic, workerParallelism, psParallelism, iterationWaitTime)
+  }
+}

--- a/src/main/scala/eu/proteus/solma/osvm/OSVMWorkerLogic.scala
+++ b/src/main/scala/eu/proteus/solma/osvm/OSVMWorkerLogic.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2017 The Proteus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.proteus.solma.osvm
+
+import breeze.linalg.{DenseMatrix, DenseVector}
+import eu.proteus.annotations.Proteus
+import eu.proteus.solma.osvm.OSVM.{OSVMModel, OSVMStreamEvent, UnlabeledVector}
+import eu.proteus.solma.osvm.algorithm.BaseOSVMAlgorithm
+import hu.sztaki.ilab.ps.{ParameterServerClient, WorkerLogic}
+import org.apache.flink.ml.math.Breeze._
+
+import scala.collection.mutable
+
+@Proteus
+class OSVMWorkerLogic(
+    algorithm: BaseOSVMAlgorithm[UnlabeledVector, Double, OSVMModel]
+  ) extends WorkerLogic[OSVMStreamEvent, OSVM.OSVMModel, (OSVM.UnlabeledVector, Double)] {
+
+  val unpredictedVecs = new mutable.Queue[OSVM.UnlabeledVector]()
+  val unlabeledVecs = new mutable.HashMap[Long, OSVM.UnlabeledVector]()
+  val labeledVecs = new mutable.Queue[(OSVM.UnlabeledVector, Double, Long)]()
+  val maxTTL: Long = 60 * 60 * 1000
+
+  override def onRecv(
+    data: OSVMStreamEvent,
+    ps: ParameterServerClient[OSVM.OSVMModel, (OSVM.UnlabeledVector, Double)]): Unit = {
+
+    data match {
+      case Left(v) =>
+        // store unlabelled point and pull
+        unpredictedVecs.enqueue(v._2.data.asBreeze)
+        unlabeledVecs(v._1) = v._2.data.asBreeze
+      case Right(v) =>
+        // we got a labelled point
+        unlabeledVecs.remove(v._1) match {
+          case Some(unlabeledVector) => labeledVecs.enqueue((unlabeledVector, v._2, v._1))
+          case None =>
+        }
+    }
+    ps.pull(0)
+  }
+
+  override def onPullRecv(
+    paramId: Int,
+    currentModel: OSVM.OSVMModel,
+    ps: ParameterServerClient[OSVM.OSVMModel, (OSVM.UnlabeledVector, Double)]): Unit = {
+
+    var modelOpt: Option[OSVM.OSVMModel] = None
+
+    while (unpredictedVecs.nonEmpty) {
+      val dataPoint = unpredictedVecs.dequeue()
+      ps.output((dataPoint, algorithm.predict(dataPoint, currentModel)))
+    }
+
+    while (labeledVecs.nonEmpty) {
+      val restedData = labeledVecs.dequeue()
+      ps.push(0, algorithm.delta(restedData._1, currentModel, restedData._2, restedData._3))
+    }
+
+  }
+}

--- a/src/main/scala/eu/proteus/solma/osvm/algorithm/BaseOSVMAlgorithm.scala
+++ b/src/main/scala/eu/proteus/solma/osvm/algorithm/BaseOSVMAlgorithm.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2017 The Proteus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.proteus.solma.osvm.algorithm
+
+import eu.proteus.annotations.Proteus
+
+@Proteus
+trait BaseOSVMAlgorithm[Vec, LabelType, Model] extends Serializable {
+
+  def delta(data: Vec, model: Model, label: LabelType, t: Long): Model
+
+  def predict(dataPoint: Vec, model: Model): LabelType
+
+}

--- a/src/main/scala/eu/proteus/solma/osvm/algorithm/OSVMAlgorithm.scala
+++ b/src/main/scala/eu/proteus/solma/osvm/algorithm/OSVMAlgorithm.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2017 The Proteus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.proteus.solma.osvm.algorithm
+
+import breeze.linalg.DenseVector
+import breeze.numerics.signum
+import eu.proteus.annotations.Proteus
+import eu.proteus.solma.osvm.OSVM
+import eu.proteus.solma.osvm.OSVM.{OSVMModel, UnlabeledVector}
+
+@Proteus
+class OSVMAlgorithm(instance: OSVM) extends BaseOSVMAlgorithm[UnlabeledVector, Double, OSVMModel]  {
+
+  override def delta(
+      dataPoint: UnlabeledVector,
+      model: OSVMModel,
+      label: Double,
+      t: Long
+  ): (DenseVector[Double], Double) = {
+
+    var sign = 1.0
+    if (label * (dataPoint dot model._1 + model._2) < 1){
+      sign = -1.0
+    }
+    val dirw = model._1 - 0.5 * label * dataPoint * sign
+    val dirb = if (sign == -1) {
+      - label * 1.0 / t
+    } else {
+      0.0
+    }
+    (dirw * (1.0 / t), dirb)
+  }
+
+  override def predict(
+      dataPoint: UnlabeledVector,
+      model: OSVMModel): Double = {
+    signum(dataPoint dot model._1 + model._2)
+  }
+}

--- a/src/test/scala/eu/proteus/solma/osvm/OSVMITSuite.scala
+++ b/src/test/scala/eu/proteus/solma/osvm/OSVMITSuite.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2017 The Proteus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.proteus.solma.osvm
+
+import eu.proteus.solma.events.StreamEvent
+import eu.proteus.solma.utils.{FlinkSolmaUtils, FlinkTestBase}
+import org.apache.flink.ml.math.{DenseVector, Vector}
+import org.apache.flink.streaming.api.scala._
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.collection.mutable.ArrayBuffer
+
+class OSVMITSuite extends FlatSpec
+    with Matchers
+    with FlinkTestBase {
+
+  behavior of "SOLMA Online SVM"
+
+  import OSVMITSuite.Sample
+
+
+  it should "perform binary OSVM" in {
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(4)
+
+
+//    val mixed = new Array[Either[(Long, Sample), (Long, Double)]](20)
+//
+//    for (i <- 0l until 10l) {
+//      mixed(i.toInt) = Left((i, Sample(0 to 2, DenseVector(Array.fill(3)(rnd.nextDouble)))))
+//    }
+//
+//    for (i <- 10l until 20l) {
+//      mixed(i.toInt) = Right((i, rnd.nextDouble() * 2.0 - 1.0))
+//    }
+
+    val osvm = OSVM()
+
+    osvm.setFeaturesCount(3)
+    osvm.setPullLimit(10000)
+    osvm.setIterationWaitTime(20000)
+
+    val ds: DataStream[Either[(Long, StreamEvent), (Long, Double)]] = env.fromCollection(OSVMITSuite.data)
+
+    osvm.transform(ds).print()
+
+
+    env.execute()
+  }
+
+}
+
+object OSVMITSuite {
+   case class Sample(
+      var slice: IndexedSeq[Int],
+      data: Vector
+  ) extends StreamEvent with Serializable
+
+
+  val rnd = new scala.util.Random()
+
+  val data: Seq[Either[(Long, Sample), (Long, Double)]] = List(
+
+    Left(1, Sample(0 to 2, DenseVector(rnd.nextDouble(), rnd.nextDouble(), rnd.nextDouble()))),
+    Left(2, Sample(0 to 2, DenseVector(rnd.nextDouble(), rnd.nextDouble(), rnd.nextDouble()))),
+    Left(3, Sample(0 to 2, DenseVector(rnd.nextDouble(), rnd.nextDouble(), rnd.nextDouble()))),
+    Left(4, Sample(0 to 2, DenseVector(rnd.nextDouble(), rnd.nextDouble(), rnd.nextDouble()))),
+    Right((1, rnd.nextDouble())),
+    Right((2, rnd.nextDouble())),
+    Right((3, rnd.nextDouble())),
+    Right((4, rnd.nextDouble()))
+
+
+  )
+}


### PR DESCRIPTION
This PR aims to introduce Online SVM for Binary Classification. The implementation is based on the parameter server. It uses a simpler skeleton than lasso. Minimal test is available.