### PR TITLE
Update OSVMAlgorithm.scala

### DIFF
--- a/src/main/scala/eu/proteus/solma/osvm/algorithm/OSVMAlgorithm.scala
+++ b/src/main/scala/eu/proteus/solma/osvm/algorithm/OSVMAlgorithm.scala
@@ -32,17 +32,14 @@ class OSVMAlgorithm(instance: OSVM) extends BaseOSVMAlgorithm[UnlabeledVector, D
       t: Long
   ): (DenseVector[Double], Double) = {
 
-    var sign = 1.0
+    var sign = 0.0
     if (label * (dataPoint dot model._1 + model._2) < 1){
-      sign = -1.0
+      sign = 1.0
     }
     val dirw = model._1 - 0.5 * label * dataPoint * sign
-    val dirb = if (sign == -1) {
-      - label * 1.0 / t
-    } else {
-      0.0
-    }
-    (dirw * (1.0 / t), dirb)
+    val dirb = - label * sign
+
+    (dirw * (1.0 / t), dirb* (1.0 / t))
   }
 
   override def predict(


### PR DESCRIPTION
I have changed the gradient calculation of OSVM. When` label * (dataPoint dot model._1 + model._2) < 1`, we should have sign = 1, otherwise sign = 0.  

The gradient dirw is  `dirw = model._1 - c * label * dataPoint * sign`. For the gradient of b, when sign =1, we have dirb = - label , And when sign = 0 , we have dirb = 0. Thus the gradient dirb is  `dirb = - label * sign`. 
