### PR TITLE
Add Obsg svm

### DIFF
--- a/src/main/scala/eu/proteus/solma/obsg_svm/OBSG_SVM.scala
+++ b/src/main/scala/eu/proteus/solma/obsg_svm/OBSG_SVM.scala
@@ -242,19 +242,6 @@ object OBSG_SVM extends WithParameters with Serializable {
     override val defaultValue: Option[Double] = Some(CParam.DefaultC)
   }
 
-  case object XpParam extends Parameter[Double] {
-    /**
-      * Default Label for unseen data
-      */
-    private val DefaultXp: DenseVector[Double] = DenseVector.zeros[Double](this.parameters)
-    /**
-      * Default value.
-      */
-    override val defaultValue: Option[Double] = Some(XpParam.DefaultXp)
-  }
-
-
-
   case object FeaturesCount extends Parameter[Int] {
     /**
       * Default output are the Weights
@@ -270,5 +257,15 @@ object OBSG_SVM extends WithParameters with Serializable {
     new OBSG_SVMPrequentialTraining
   }
 
+  case object XpParam extends Parameter[DenseVector[Double]] {
+    /**
+      * Default Label for unseen data
+      */
+    private val DefaultXp: DenseVector[Double] = DenseVector.zeros[Double](8)
+    /**
+      * Default value.
+      */
+    override val defaultValue: Option[DenseVector[Double]] = Some(XpParam.DefaultXp)
+  }
 
 }

--- a/src/main/scala/eu/proteus/solma/obsg_svm/OBSG_SVM.scala
+++ b/src/main/scala/eu/proteus/solma/obsg_svm/OBSG_SVM.scala
@@ -65,6 +65,11 @@ class OBSG_SVM extends StreamTransformer[OBSG_SVM]{
     this.parameters.get(OBSG_SVM.CParam).get
   }
 
+  /**
+    * Set the Xp value a
+    * @param xp the xp param of OBSG_SVM
+    * @return
+    */
   def setXpParam(xp : DenseVector[Double]): OBSG_SVM = {
     this.parameters.add(XpParam, xp)
     this
@@ -77,6 +82,22 @@ class OBSG_SVM extends StreamTransformer[OBSG_SVM]{
     this.parameters.get(OBSG_SVM.XpParam).get
   }
 
+  /**
+    * Set the Yp value a
+    * @param yp the yp param of OBSG_SVM
+    * @return
+    */
+  def setYpParam(yp : Double): OBSG_SVM = {
+    this.parameters.add(YpParam, yp)
+    this
+  }
+
+  /** Get the Yp param
+    * @return The Yp param
+    */
+  def getYpParam() : Double  = {
+    this.parameters.get(OBSG_SVM.XpParam).get
+  }
 
   /**
     * Get the SeverParallism value as Int
@@ -266,6 +287,16 @@ object OBSG_SVM extends WithParameters with Serializable {
       * Default value.
       */
     override val defaultValue: Option[DenseVector[Double]] = Some(XpParam.DefaultXp)
+  }
+  case object YpParam extends Parameter[Double] {
+    /**
+      * Default Label for unseen data
+      */
+    private val DefaultYp: Double = 1.0
+    /**
+      * Default value.
+      */
+    override val defaultValue: Option[Double] = Some(YpParam.DefaultYp)
   }
 
 }

--- a/src/main/scala/eu/proteus/solma/obsg_svm/OBSG_SVM.scala
+++ b/src/main/scala/eu/proteus/solma/obsg_svm/OBSG_SVM.scala
@@ -78,8 +78,8 @@ class OBSG_SVM extends StreamTransformer[OBSG_SVM]{
   /** Get the Xp param
     * @return The Xp param
     */
-  def getXpParam() : DenseVector[Double]  = {
-    this.parameters.get(OBSG_SVM.XpParam).get
+  def getXpParam() : Option[DenseVector[Double]]  = {
+    this.parameters.get(OBSG_SVM.XpParam)
   }
 
   /**
@@ -280,13 +280,9 @@ object OBSG_SVM extends WithParameters with Serializable {
 
   case object XpParam extends Parameter[DenseVector[Double]] {
     /**
-      * Default Label for unseen data
-      */
-    private val DefaultXp: DenseVector[Double] = DenseVector.zeros[Double](8)
-    /**
       * Default value.
       */
-    override val defaultValue: Option[DenseVector[Double]] = Some(XpParam.DefaultXp)
+    override val defaultValue: Option[DenseVector[Double]] = None
   }
   case object YpParam extends Parameter[Double] {
     /**

--- a/src/main/scala/eu/proteus/solma/obsg_svm/OBSG_SVM.scala
+++ b/src/main/scala/eu/proteus/solma/obsg_svm/OBSG_SVM.scala
@@ -96,7 +96,7 @@ class OBSG_SVM extends StreamTransformer[OBSG_SVM]{
     * @return The Yp param
     */
   def getYpParam() : Double  = {
-    this.parameters.get(OBSG_SVM.XpParam).get
+    this.parameters.get(OBSG_SVM.YpParam).get
   }
 
   /**

--- a/src/main/scala/eu/proteus/solma/obsg_svm/OBSG_SVM.scala
+++ b/src/main/scala/eu/proteus/solma/obsg_svm/OBSG_SVM.scala
@@ -1,0 +1,274 @@
+/*
+ * Copyright (C) 2017 The Proteus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.proteus.solma.obsg_svm
+
+import breeze.linalg.{DenseMatrix, DenseVector, Vector}
+import eu.proteus.annotations.Proteus
+import eu.proteus.solma.events.{StreamEvent, StreamEventLabel, StreamEventWithPos}
+import eu.proteus.solma.pipeline.StreamTransformer
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.ml.common.{Parameter, WithParameters}
+import org.slf4j.Logger
+
+import scala.reflect.ClassTag
+
+@Proteus
+class OBSG_SVM extends StreamTransformer[OBSG_SVM]{
+
+  import eu.proteus.solma.obsg_svm.OBSG_SVM._
+
+  /** Get the WorkerParallism value as Int
+    * @return The number of worker parallelism
+    */
+  def getWorkerParallelism() : Int  = {
+    this.parameters.get(OBSG_SVM.WorkerParallism).get
+  }
+
+  /**
+    * Set the WorkerParallelism value as Int
+    * @param workerParallism workerParallism as Int
+    * @return
+    */
+  def setWorkerParallelism(workerParallism : Int): OBSG_SVM = {
+    this.parameters.add(WorkerParallism, workerParallism)
+    this
+  }
+
+  /**
+    * Set the C value a
+    * @param c the c param of OBSG_SVM
+    * @return
+    */
+  def setCParam(c : Double): OBSG_SVM = {
+    this.parameters.add(CParam, c)
+    this
+  }
+
+  /** Get the C param
+    * @return The C param
+    */
+  def getCParam() : Double  = {
+    this.parameters.get(OBSG_SVM.CParam).get
+  }
+
+  def setXpParam(xp : DenseVector[Double]): OBSG_SVM = {
+    this.parameters.add(XpParam, xp)
+    this
+  }
+
+  /** Get the Xp param
+    * @return The Xp param
+    */
+  def getXpParam() : DenseVector[Double]  = {
+    this.parameters.get(OBSG_SVM.XpParam).get
+  }
+
+
+  /**
+    * Get the SeverParallism value as Int
+    * @return The number of server parallelism
+    */
+  def getPSParallelism() : Int  = {
+    this.parameters.get(PSParallelism).get
+  }
+  /**
+    * Set the SeverParallism value as Int
+    * @param psParallelism serverparallelism as Int
+    * @return
+    */
+  def setPSParallelism(psParallelism : Int): OBSG_SVM = {
+    parameters.add(PSParallelism, psParallelism)
+    this
+  }
+  /**
+    * Variable to stop the calculation in stream environment
+    * @param iterationWaitTime time as ms (long)
+    * @return
+    */
+  def setIterationWaitTime(iterationWaitTime: Long) : OBSG_SVM = {
+    parameters.add(IterationWaitTime, iterationWaitTime)
+    this
+  }
+  /** Variable to stop the calculation in stream environment
+    * get the waiting time
+    * @return The waiting time as Long
+    */
+  def getIterationWaitTime() : Long  = {
+    this.parameters.get(IterationWaitTime).get
+  }
+
+  /**
+    * set a pull limit
+    * @param pullLimit
+    */
+  def setPullLimit(pullLimit : Int) : OBSG_SVM = {
+    this.parameters.add(PullLimit, pullLimit)
+    this
+  }
+  /**
+    * Get the pull limit
+    * @return The pull limit
+    */
+  def getPullLimit(): Int = {
+    this.parameters.get(PullLimit).get
+  }
+
+  /**
+    * set allowed lateness
+    * @param allowedLateness
+    */
+  def setAllowedLateness(allowedLateness: Int) : OBSG_SVM = {
+    this.parameters.add(AllowedLateness, allowedLateness)
+    this
+  }
+  /**
+    * Get the allowed lateness
+    * @return The allowed lateness
+    */
+  def getAllowedLateness(): Int = {
+    this.parameters.get(AllowedLateness).get
+  }
+
+  /**
+    * set a pull
+    * @param featuresCount
+    */
+  def setFeaturesCount(featuresCount: Int) : OBSG_SVM = {
+    this.parameters.add(FeaturesCount, featuresCount)
+    this
+  }
+  /**
+    * Get the Windowsize
+    * @return The windowsize
+    */
+  def getFeaturesCount(): Int = {
+    this.parameters.get(FeaturesCount).get
+  }
+
+}
+
+object OBSG_SVM extends WithParameters with Serializable {
+
+  type OBSG_SVMStreamEvent = Either[(Long, StreamEvent), Label]
+  type OBSG_SVMModel = (DenseVector[Double], Double)
+  type UnlabeledVector = Vector[Double]
+  type Label = (Long, Double)
+
+  /**
+    * Apply helper.
+    * @return A new [[OBSG_SVM]].
+    */
+  def apply(): OBSG_SVM = {
+    new OBSG_SVM()
+  }
+
+  /**
+    * Class logger.
+    */
+  private val Log: Logger = org.slf4j.LoggerFactory.getLogger(this.getClass.getName)
+
+  case object IterationWaitTime extends Parameter[Long] {
+    /**
+      * Default time - needs to be set in any case to stop this calculation
+      */
+    private val DefaultIterationWaitTime: Long = 4000
+    /**
+      * Default value.
+      */
+    override val defaultValue: Option[Long] = Some(IterationWaitTime.DefaultIterationWaitTime)
+  }
+  case object WorkerParallism extends Parameter[Int] {
+    /**
+      * Default parallelism
+      */
+    private val DefaultWorkerParallism: Int = 4
+    /**
+      * Default value.
+      */
+    override val defaultValue: Option[Int] = Some(WorkerParallism.DefaultWorkerParallism)
+  }
+  case object PullLimit extends Parameter[Int] {
+    /**
+      * Default parallelism
+      */
+    private val DefaultPullLimit: Int = 20000
+    /**
+      * Default value.
+      */
+    override val defaultValue: Option[Int] = Some(PullLimit.DefaultPullLimit)
+  }
+  case object PSParallelism extends Parameter[Int] {
+    /**
+      * Default server parallelism.
+      */
+    private val DefaultPSParallelism: Int = 4
+    /**
+      * Default value.
+      */
+    override val defaultValue: Option[Int] = Some(PSParallelism.DefaultPSParallelism)
+  }
+  case object AllowedLateness extends Parameter[Int] {
+    /**
+      * Default Label for unseen data
+      */
+    private val AllowedLatenessDefault: Int = 1
+    /**
+      * Default value.
+      */
+    override val defaultValue: Option[Int] = Some(AllowedLateness.AllowedLatenessDefault)
+  }
+  case object CParam extends Parameter[Double] {
+    /**
+      * Default Label for unseen data
+      */
+    private val DefaultC: Double = 0.5
+    /**
+      * Default value.
+      */
+    override val defaultValue: Option[Double] = Some(CParam.DefaultC)
+  }
+
+  case object XpParam extends Parameter[Double] {
+    /**
+      * Default Label for unseen data
+      */
+    private val DefaultXp: DenseVector[Double] = DenseVector.zeros[Double](this.parameters)
+    /**
+      * Default value.
+      */
+    override val defaultValue: Option[Double] = Some(XpParam.DefaultXp)
+  }
+
+
+
+  case object FeaturesCount extends Parameter[Int] {
+    /**
+      * Default output are the Weights
+      */
+    private val DefaultFeaturesCount: Int = -1
+    /**
+      * Default value.
+      */
+    override val defaultValue: Option[Int] = Some(FeaturesCount.DefaultFeaturesCount)
+  }
+
+  implicit def transformStreamImplementation = {
+    new OBSG_SVMPrequentialTraining
+  }
+
+
+}

--- a/src/main/scala/eu/proteus/solma/obsg_svm/OBSG_SVMPrequentialTraining.scala
+++ b/src/main/scala/eu/proteus/solma/obsg_svm/OBSG_SVMPrequentialTraining.scala
@@ -61,7 +61,8 @@ class OBSG_SVMPrequentialTraining extends TransformDataStreamOperation[
                                     instance: OBSG_SVM,
                                     transformParameters: ParameterMap,
                                     input: DataStream[OBSG_SVMStreamEvent]
-                                  ): DataStream[Either[(Long, OBSG_SVM.UnlabeledVector, Double), (Int, OBSG_SVM.OBSG_SVMModel)]] = {
+                                  ): DataStream[Either[(Long, OBSG_SVM.UnlabeledVector, Double),
+                                    (Int, OBSG_SVM.OBSG_SVMModel)]] = {
 
     val workerParallelism: Int = instance.getWorkerParallelism
     val psParallelism: Int  = instance.getPSParallelism

--- a/src/main/scala/eu/proteus/solma/obsg_svm/OBSG_SVMPrequentialTraining.scala
+++ b/src/main/scala/eu/proteus/solma/obsg_svm/OBSG_SVMPrequentialTraining.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2017 The Proteus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.proteus.solma.obsg_svm
+
+import org.apache.flink.ml.common.ParameterMap
+import org.apache.flink.streaming.api.scala._
+import breeze.linalg.{DenseMatrix, DenseVector, diag, randomDouble}
+import eu.proteus.annotations.Proteus
+import eu.proteus.solma.obsg_svm.OBSG_SVM.OBSG_SVMStreamEvent
+import eu.proteus.solma.obsg_svm.algorithm.OBSG_SVMAlgorithm
+import eu.proteus.solma.pipeline.TransformDataStreamOperation
+import hu.sztaki.ilab.ps.entities.{PSToWorker, Pull, Push, WorkerToPS}
+import hu.sztaki.ilab.ps.server.RangePSLogicWithClose
+import hu.sztaki.ilab.ps.{FlinkParameterServer, WorkerLogic}
+import org.apache.flink.api.common.functions.Partitioner
+import org.apache.flink.util.XORShiftRandom
+
+@Proteus
+class OBSG_SVMPrequentialTraining extends TransformDataStreamOperation[
+  OBSG_SVM,
+  OBSG_SVM.OBSG_SVMStreamEvent,
+  Either[(Long, OBSG_SVM.UnlabeledVector, Double), (Int, OBSG_SVM.OBSG_SVMModel)]] {
+
+
+  def init(n : Int, minW: Double, maxW: Double, minBias: Double, maxBias: Double): Int => OBSG_SVM.OBSG_SVMModel =
+    _ => {
+      val w = randomDouble(n, (minW, maxW))
+      val bias = randomDouble(1, (minBias, maxBias))
+      (w, bias(0))
+    }
+
+  def rangePartitionerPS[P](featureCount: Int)(psParallelism: Int): WorkerToPS[P] => Int = {
+    val partitionSize = Math.ceil(featureCount.toDouble / psParallelism).toInt
+    val partitonerFunction = (paramId: Int) => Math.abs(paramId) / partitionSize
+
+    val paramPartitioner: WorkerToPS[P] => Int = {
+      case WorkerToPS(_, msg) => msg match {
+        case Left(Pull(paramId)) => partitonerFunction(paramId)
+        case Right(Push(paramId, _)) => partitonerFunction(paramId)
+      }
+    }
+
+    paramPartitioner
+  }
+
+  override def transformDataStream(
+                                    instance: OBSG_SVM,
+                                    transformParameters: ParameterMap,
+                                    input: DataStream[OBSG_SVMStreamEvent]
+                                  ): DataStream[Either[(Long, OBSG_SVM.UnlabeledVector, Double), (Int, OBSG_SVM.OBSG_SVMModel)]] = {
+
+    val workerParallelism: Int = instance.getWorkerParallelism
+    val psParallelism: Int  = instance.getPSParallelism
+    val pullLimit: Int  = instance.getPullLimit
+    val featureCount: Int  = instance.getFeaturesCount
+    val iterationWaitTime: Long  = instance.getIterationWaitTime
+    val allowedLateness: Long  = instance.getAllowedLateness
+
+    val updater = (currModel: OBSG_SVM.OBSG_SVMModel, gradient: OBSG_SVM.OBSG_SVMModel) => {
+      (currModel._1 - gradient._1, currModel._2 - gradient._2)
+    }
+
+    val rnd = new XORShiftRandom()
+
+    val initializer = init(featureCount, -8.0, 4.0, -1.0, 1.0)
+
+    val workerLogic =  WorkerLogic.addPullLimiter(
+      new OBSG_SVMWorkerLogic(
+        new OBSG_SVMAlgorithm(instance)),
+      pullLimit)
+
+    val serverLogic = new RangePSLogicWithClose[OBSG_SVM.OBSG_SVMModel](featureCount, initializer, updater)
+    val paramPartitioner: WorkerToPS[OBSG_SVM.OBSG_SVMModel] => Int = rangePartitionerPS(featureCount)(psParallelism)
+
+    val wInPartition: PSToWorker[OBSG_SVM.OBSG_SVMModel] => Int = {
+      case PSToWorker(workerPartitionIndex, _) => workerPartitionIndex
+    }
+
+    implicit val inputTypeInfo = createTypeInformation[OBSG_SVMStreamEvent]
+
+    val partitionedInput = input.partitionCustom(
+      new Partitioner[Long] {
+        override def partition(k: Long, total: Int): Int = {
+          (k % total).toInt
+        }
+      },
+      (event: OBSG_SVM.OBSG_SVMStreamEvent) => event match {
+        case Left(v) => v._1
+        case Right(v) => v._1
+      })
+
+    FlinkParameterServer.transform(
+      partitionedInput,
+      workerLogic,
+      serverLogic,
+      workerParallelism,
+      psParallelism,
+      iterationWaitTime
+    )
+  }
+}

--- a/src/main/scala/eu/proteus/solma/obsg_svm/OBSG_SVMWorkerLogic.scala
+++ b/src/main/scala/eu/proteus/solma/obsg_svm/OBSG_SVMWorkerLogic.scala
@@ -29,7 +29,8 @@ import scala.collection.mutable
 @Proteus
 class OBSG_SVMWorkerLogic(
                        algorithm: BaseOBSG_SVMAlgorithm[UnlabeledVector, Double, OBSG_SVMModel]
-                     ) extends WorkerLogic[OBSG_SVMStreamEvent, OBSG_SVM.OBSG_SVMModel, (Long, OBSG_SVM.UnlabeledVector, Double)] {
+                     ) extends WorkerLogic[OBSG_SVMStreamEvent, OBSG_SVM.OBSG_SVMModel,
+                       (Long, OBSG_SVM.UnlabeledVector, Double)] {
 
   val unpredictedVecs = new mutable.Queue[(Long, OBSG_SVM.UnlabeledVector)]()
   val unlabeledVecs = new mutable.HashMap[Long, OBSG_SVM.UnlabeledVector]()
@@ -39,7 +40,8 @@ class OBSG_SVMWorkerLogic(
 
   override def onRecv(
                        data: OBSG_SVMStreamEvent,
-                       ps: ParameterServerClient[OBSG_SVM.OBSG_SVMModel, (Long, OBSG_SVM.UnlabeledVector, Double)]): Unit = {
+                       ps: ParameterServerClient[OBSG_SVM.OBSG_SVMModel,
+                         (Long, OBSG_SVM.UnlabeledVector, Double)]): Unit = {
 
     data match {
       case Left((index, dataPoint)) =>
@@ -59,7 +61,8 @@ class OBSG_SVMWorkerLogic(
   override def onPullRecv(
                            paramId: Int,
                            currentModel: OBSG_SVM.OBSG_SVMModel,
-                           ps: ParameterServerClient[OBSG_SVM.OBSG_SVMModel, (Long, OBSG_SVM.UnlabeledVector, Double)]): Unit = {
+                           ps: ParameterServerClient[OBSG_SVM.OBSG_SVMModel,
+                             (Long, OBSG_SVM.UnlabeledVector, Double)]): Unit = {
 
     var modelOpt: Option[OBSG_SVM.OBSG_SVMModel] = None
 

--- a/src/main/scala/eu/proteus/solma/obsg_svm/OBSG_SVMWorkerLogic.scala
+++ b/src/main/scala/eu/proteus/solma/obsg_svm/OBSG_SVMWorkerLogic.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2017 The Proteus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.proteus.solma.obsg_svm
+
+import breeze.linalg.{DenseMatrix, DenseVector}
+import eu.proteus.annotations.Proteus
+import eu.proteus.solma.obsg_svm.OBSG_SVM.{OBSG_SVMModel, OBSG_SVMStreamEvent, UnlabeledVector}
+import eu.proteus.solma.obsg_svm.algorithm.BaseOBSG_SVMAlgorithm
+import eu.proteus.solma.utils.BinaryConfusionMatrixBuilder
+import hu.sztaki.ilab.ps.{ParameterServerClient, WorkerLogic}
+import org.apache.flink.ml.math.Breeze._
+
+import scala.collection.mutable
+
+@Proteus
+class OBSG_SVMWorkerLogic(
+                       algorithm: BaseOBSG_SVMAlgorithm[UnlabeledVector, Double, OBSG_SVMModel]
+                     ) extends WorkerLogic[OBSG_SVMStreamEvent, OBSG_SVM.OBSG_SVMModel, (Long, OBSG_SVM.UnlabeledVector, Double)] {
+
+  val unpredictedVecs = new mutable.Queue[(Long, OBSG_SVM.UnlabeledVector)]()
+  val unlabeledVecs = new mutable.HashMap[Long, OBSG_SVM.UnlabeledVector]()
+  val labeledVecs = new mutable.Queue[(OBSG_SVM.UnlabeledVector, Double, Long)]()
+
+  val cfBuilder = new BinaryConfusionMatrixBuilder
+
+  override def onRecv(
+                       data: OBSG_SVMStreamEvent,
+                       ps: ParameterServerClient[OBSG_SVM.OBSG_SVMModel, (Long, OBSG_SVM.UnlabeledVector, Double)]): Unit = {
+
+    data match {
+      case Left((index, dataPoint)) =>
+        // store unlabelled point and pull
+        unpredictedVecs.enqueue((index, dataPoint.data.asBreeze))
+        unlabeledVecs(index) = dataPoint.data.asBreeze
+      case Right((index, expected)) =>
+        // we got a labelled point
+        unlabeledVecs.remove(index) match {
+          case Some(unlabeledVector) => labeledVecs.enqueue((unlabeledVector, expected, index))
+          case None => throw new IllegalStateException("Got label for unseen data point")
+        }
+    }
+    ps.pull(0)
+  }
+
+  override def onPullRecv(
+                           paramId: Int,
+                           currentModel: OBSG_SVM.OBSG_SVMModel,
+                           ps: ParameterServerClient[OBSG_SVM.OBSG_SVMModel, (Long, OBSG_SVM.UnlabeledVector, Double)]): Unit = {
+
+    var modelOpt: Option[OBSG_SVM.OBSG_SVMModel] = None
+
+    while (unpredictedVecs.nonEmpty) {
+      val (index, dataPoint) = unpredictedVecs.dequeue()
+      ps.output((index, dataPoint, algorithm.predict(dataPoint, currentModel)))
+    }
+
+    while (labeledVecs.nonEmpty) {
+      val (dataPoint, prediction, index) = labeledVecs.dequeue()
+      ps.push(0, algorithm.delta(dataPoint, currentModel, prediction, index))
+    }
+
+  }
+}

--- a/src/main/scala/eu/proteus/solma/obsg_svm/algorithm/BaseOBSG_SVMAlgorithm.scala
+++ b/src/main/scala/eu/proteus/solma/obsg_svm/algorithm/BaseOBSG_SVMAlgorithm.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2017 The Proteus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.proteus.solma.obsg_svm.algorithm
+
+import eu.proteus.annotations.Proteus
+
+@Proteus
+trait BaseOBSG_SVMAlgorithm[Vec, LabelType, Model] extends Serializable {
+
+  def delta(data: Vec, model: Model, label: LabelType, t: Long): Model
+
+  def predict(dataPoint: Vec, model: Model): LabelType
+
+}

--- a/src/main/scala/eu/proteus/solma/obsg_svm/algorithm/OBSG_SVMAlgorithm.scala
+++ b/src/main/scala/eu/proteus/solma/obsg_svm/algorithm/OBSG_SVMAlgorithm.scala
@@ -47,14 +47,13 @@ class OBSG_SVMAlgorithm(instance: OBSG_SVM) extends BaseOBSG_SVMAlgorithm[Unlabe
 
        c += - (1.0 / t) * (yp * xp) dot (label * dataPoint)
 
-
       instance.setCParam(c)
       instance.setXpParam(dataPoint.toDenseVector)
       instance.setYpParam(label)
     }
 
 
-    
+
     (dirw * (1.0 / t), dirb * (1.0 / t))
   }
 

--- a/src/main/scala/eu/proteus/solma/obsg_svm/algorithm/OBSG_SVMAlgorithm.scala
+++ b/src/main/scala/eu/proteus/solma/obsg_svm/algorithm/OBSG_SVMAlgorithm.scala
@@ -34,26 +34,27 @@ class OBSG_SVMAlgorithm(instance: OBSG_SVM) extends BaseOBSG_SVMAlgorithm[Unlabe
 
     var c = instance.getCParam()
     val xp = instance.getXpParam()
+    val yp = instance.getYpParam()
 
     var dirw = DenseVector.zeros[Double](dataPoint.length)
     var dirb : Double = 0.0
 
-    //var sign = 0.0
+
     if (label * (dataPoint dot model._1 + model._2) < 1){
-      //  sign = 1.0
+
        dirw = model._1 - c * label * dataPoint
        dirb = - label
 
-      c = c + (1.0 / t) * xp dot (label * dataPoint)
+       c += - (1.0 / t) * (yp * xp) dot (label * dataPoint)
 
 
       instance.setCParam(c)
       instance.setXpParam(dataPoint.toDenseVector)
+      instance.setYpParam(label)
     }
 
 
-
-
+    
     (dirw * (1.0 / t), dirb * (1.0 / t))
   }
 

--- a/src/main/scala/eu/proteus/solma/obsg_svm/algorithm/OBSG_SVMAlgorithm.scala
+++ b/src/main/scala/eu/proteus/solma/obsg_svm/algorithm/OBSG_SVMAlgorithm.scala
@@ -33,7 +33,13 @@ class OBSG_SVMAlgorithm(instance: OBSG_SVM) extends BaseOBSG_SVMAlgorithm[Unlabe
                     ): (DenseVector[Double], Double) = {
 
     var c = instance.getCParam()
-    val xp = instance.getXpParam()
+    val XpParam = instance.getXpParam()
+    var xp = DenseVector[Double](dataPoint.length)
+    if (XpParam == None) {
+      xp = DenseVector.zeros[Double](dataPoint.length)
+    } else {
+      xp = XpParam.get
+    }
     val yp = instance.getYpParam()
 
     var dirw = DenseVector.zeros[Double](dataPoint.length)

--- a/src/main/scala/eu/proteus/solma/obsg_svm/algorithm/OBSG_SVMAlgorithm.scala
+++ b/src/main/scala/eu/proteus/solma/obsg_svm/algorithm/OBSG_SVMAlgorithm.scala
@@ -44,16 +44,13 @@ class OBSG_SVMAlgorithm(instance: OBSG_SVM) extends BaseOBSG_SVMAlgorithm[Unlabe
        dirw = model._1 - c * label * dataPoint
        dirb = - label
 
-      c = (1.0 / t) * xp dot (label * dataPoint)
+      c = c + (1.0 / t) * xp dot (label * dataPoint)
 
 
       instance.setCParam(c)
       instance.setXpParam(dataPoint.toDenseVector)
     }
-    //val dirw = model._1 - c * label * dataPoint * sign
-    //val dirb = - label * sign
 
-    //c = c + (1.0 / t) * xp dot (label * dataPoint) * sign
 
 
 

--- a/src/main/scala/eu/proteus/solma/obsg_svm/algorithm/OBSG_SVMAlgorithm.scala
+++ b/src/main/scala/eu/proteus/solma/obsg_svm/algorithm/OBSG_SVMAlgorithm.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2017 The Proteus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.proteus.solma.obsg_svm.algorithm
+
+import breeze.linalg.DenseVector
+import breeze.numerics.signum
+import eu.proteus.annotations.Proteus
+import eu.proteus.solma.obsg_svm.OBSG_SVM
+import eu.proteus.solma.obsg_svm.OBSG_SVM.{OBSG_SVMModel, UnlabeledVector}
+
+@Proteus
+class OBSG_SVMAlgorithm(instance: OBSG_SVM) extends BaseOBSG_SVMAlgorithm[UnlabeledVector, Double, OBSG_SVMModel]  {
+
+  override def delta(
+                      dataPoint: UnlabeledVector,
+                      model: OBSG_SVMModel,
+                      label: Double,
+                      t: Long
+                    ): (DenseVector[Double], Double) = {
+
+    var c = instance.getCParam()
+    val xp = instance.getXpParam()
+
+    var dirw = DenseVector.zeros[Double](dataPoint.length)
+    var dirb : Double = 0.0
+
+    //var sign = 0.0
+    if (label * (dataPoint dot model._1 + model._2) < 1){
+      //  sign = 1.0
+       dirw = model._1 - c * label * dataPoint
+       dirb = - label
+
+      c = c + (1.0 / t) * xp dot (label * dataPoint)
+
+
+      instance.setCParam(c)
+      instance.setXpParam(dataPoint)
+    }
+    //val dirw = model._1 - c * label * dataPoint * sign
+    //val dirb = - label * sign
+
+    //c = c + (1.0 / t) * xp dot (label * dataPoint) * sign
+
+
+
+    (dirw * (1.0 / t), dirb * (1.0 / t))
+  }
+
+  override def predict(
+                        dataPoint: UnlabeledVector,
+                        model: OBSG_SVMModel): Double = {
+    signum(dataPoint dot model._1 + model._2)
+  }
+}

--- a/src/main/scala/eu/proteus/solma/obsg_svm/algorithm/OBSG_SVMAlgorithm.scala
+++ b/src/main/scala/eu/proteus/solma/obsg_svm/algorithm/OBSG_SVMAlgorithm.scala
@@ -44,11 +44,11 @@ class OBSG_SVMAlgorithm(instance: OBSG_SVM) extends BaseOBSG_SVMAlgorithm[Unlabe
        dirw = model._1 - c * label * dataPoint
        dirb = - label
 
-      c = c + (1.0 / t) * xp dot (label * dataPoint)
+      c = (1.0 / t) * xp dot (label * dataPoint)
 
 
       instance.setCParam(c)
-      instance.setXpParam(dataPoint)
+      instance.setXpParam(dataPoint.toDenseVector)
     }
     //val dirw = model._1 - c * label * dataPoint * sign
     //val dirb = - label * sign

--- a/src/main/scala/eu/proteus/solma/obsg_svm/algorithm/OBSG_SVMAlgorithm.scala
+++ b/src/main/scala/eu/proteus/solma/obsg_svm/algorithm/OBSG_SVMAlgorithm.scala
@@ -36,7 +36,7 @@ class OBSG_SVMAlgorithm(instance: OBSG_SVM) extends BaseOBSG_SVMAlgorithm[Unlabe
     val XpParam = instance.getXpParam()
     var xp = DenseVector[Double](dataPoint.length)
     if (XpParam == None) {
-      xp = DenseVector.zeros[Double](dataPoint.length)
+      xp = dataPoint.toDenseVector
     } else {
       xp = XpParam.get
     }

--- a/src/test/scala/eu/proteus/solma/obsg_svm/OBSG_SVMITSuite.scala
+++ b/src/test/scala/eu/proteus/solma/obsg_svm/OBSG_SVMITSuite.scala
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) 2017 The Proteus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.proteus.solma.obsg_svm
+
+import breeze.linalg
+import eu.proteus.solma.events.StreamEvent
+import eu.proteus.solma.obsg_svm.OBSG_SVM.UnlabeledVector
+import eu.proteus.solma.utils.{BinaryConfusionMatrix, BinaryConfusionMatrixBuilder, FlinkSolmaUtils, FlinkTestBase}
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.ml.math.{DenseVector, Vector}
+import org.apache.flink.streaming.api.functions.co.RichCoFlatMapFunction
+import org.apache.flink.streaming.api.scala._
+import org.apache.flink.streaming.api.scala.extensions._
+import org.apache.flink.util.Collector
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.slf4j
+import org.slf4j.LoggerFactory
+
+import scala.collection.mutable
+import scala.io.Source
+
+class OBSG_SVMITSuite extends FlatSpec
+  with Matchers
+  with BeforeAndAfterAll
+  with FlinkTestBase {
+
+  import OBSG_SVMITSuite._
+
+  val dataSemiShuffled = new mutable.ArrayBuffer[Either[(Long, Sample), (Long, Double)]]()
+
+  val dataNotShuffled = new mutable.ArrayBuffer[Either[(Long, Sample), (Long, Double)]]()
+
+  behavior of "SOLMA Online OBSG_SVM"
+
+  override def beforeAll(): Unit = {
+
+    val bufferedSource = Source.fromInputStream(getClass.getResourceAsStream("/nursey.csv"))
+    var i = 0L
+
+    val unlabelled = new mutable.HashMap[Long, Sample]()
+    val labelled = new mutable.HashMap[Long, Double]()
+
+    for (line <- bufferedSource.getLines) {
+      val v = line.split(";").map(_.trim.toDouble)
+      if (v.length > 0) {
+        unlabelled(i) = Sample(0 to 7, DenseVector(v.take(8)))
+        labelled(i) = v(8)
+        dataNotShuffled.append(Left((i, unlabelled(i))))
+        dataNotShuffled.append(Right((i, labelled(i))))
+        i += 1
+      }
+    }
+
+    var j = 0
+    var k = 0
+
+    val max = i
+    i *= 2
+
+    // we want to split the data points from their labels
+    // invariant: the i-th data point has to appear before than the i-th label
+
+    while (i > 0) {
+      val p = rnd.nextDouble()
+      if (p > 0.8 && j < max) {
+        // take the j-th data point
+        if (j >= k) {
+          // make sure the j-th data point is after the k-th label
+          dataSemiShuffled.append(Left((j, unlabelled(j))))
+          j += 1
+          i -= 1
+        } else {
+          // let's take the k-th label
+          dataSemiShuffled.append(Right((k, labelled(k))))
+          k += 1
+          i -= 1
+        }
+      } else {
+        if (k < j) {
+          dataSemiShuffled.append(Right((k, labelled(k))))
+          k += 1
+          i -= 1
+        } else {
+          dataSemiShuffled.append(Left((j, unlabelled(j))))
+          j += 1
+          i -= 1
+        }
+      }
+    }
+
+  }
+
+  it should "perform binary OBSG_SVM on plain Nursey data" in {
+    helper(dataNotShuffled)
+  }
+
+  it should "perform binary OBSG_SVM on semi shuffled Nursey data" in {
+    helper(dataSemiShuffled)
+  }
+
+
+}
+
+object OBSG_SVMITSuite {
+  case class Sample(
+                     var slice: IndexedSeq[Int],
+                     data: Vector
+                   ) extends StreamEvent with Serializable
+
+  val LOG: slf4j.Logger = LoggerFactory.getLogger(OBSG_SVMITSuite.getClass)
+
+  val rnd = new scala.util.Random()
+
+
+  def helper(data: Seq[Either[(Long, StreamEvent), (Long, Double)]]): Unit = {
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(4)
+
+    val obsg_svm = OBSG_SVM()
+      .setCParam(0.35)
+      .setFeaturesCount(8)
+      .setPullLimit(10000)
+      .setIterationWaitTime(20000)
+
+
+    val ds: DataStream[Either[(Long, StreamEvent), (Long, Double)]] = env.fromCollection(data)
+
+    val predictionsAndModel = obsg_svm.transform(ds)
+
+    predictionsAndModel.flatMapWith {
+      case x =>
+        x match {
+          case Right(model) =>
+            List(model)
+          case Left(_) =>
+            List()
+        }
+    }.print
+
+    predictionsAndModel
+      .connect(ds.flatMapWith {
+        case x =>
+          x match {
+            case Right(x: (Long, Double)) => List(x)
+            case Left(_) => List()
+          }
+      })
+      .flatMap(new RichCoFlatMapFunction[Either[(Long, UnlabeledVector, Double),
+        (Int, (linalg.DenseVector[Double], Double))], (Long, Double), BinaryConfusionMatrix] {
+
+        @transient var cfBuilder: BinaryConfusionMatrixBuilder = _
+
+        @transient var predictions: mutable.HashMap[Long, Double] = _
+        @transient var expected: mutable.HashMap[Long, Double] = _
+
+        override def open(parameters: Configuration): Unit = {
+          super.open(parameters)
+          cfBuilder = new BinaryConfusionMatrixBuilder
+          predictions = new mutable.HashMap[Long, Double]()
+          expected = new mutable.HashMap[Long, Double]()
+        }
+
+        override def flatMap1(
+                               value: Either[(Long, UnlabeledVector, Double), (Int, (linalg.DenseVector[Double], Double))],
+                               out: Collector[BinaryConfusionMatrix]
+                             ): Unit = {
+          value match {
+            case Left((index, point, prediction)) => {
+              // due to parallel processing, it might happen that an outcome arrives here
+              // earlier than the actual prediction
+              expected.remove(index) match {
+                case Some(expectedPrediction) => {
+                  cfBuilder.add(prediction, expectedPrediction)
+                  out.collect(cfBuilder.toConfusionMatrix)
+                }
+                case None => predictions(index) = prediction
+              }
+
+            }
+            case Right(_) => // do nothing with the last updated model
+          }
+        }
+
+        override def flatMap2(
+                               value: (Long, Double),
+                               out: Collector[BinaryConfusionMatrix]): Unit = {
+
+          val (index, expectedPrediction) = value
+
+          predictions.remove(index) match {
+            case Some(predictedOutcome) => {
+              cfBuilder.add(predictedOutcome, expectedPrediction)
+              out.collect(cfBuilder.toConfusionMatrix)
+            }
+            case None => expected(index) = expectedPrediction
+          }
+
+
+        }
+      })
+      .setParallelism(1)
+      .print.setParallelism(1)
+
+
+    env.execute()
+  }
+
+
+}

--- a/src/test/scala/eu/proteus/solma/obsg_svm/OBSG_SVMITSuite.scala
+++ b/src/test/scala/eu/proteus/solma/obsg_svm/OBSG_SVMITSuite.scala
@@ -132,7 +132,7 @@ object OBSG_SVMITSuite {
     env.setParallelism(4)
 
     val obsg_svm = OBSG_SVM()
-      .setCParam(1)
+      .setCParam(0.1)
       .setFeaturesCount(8)
       .setPullLimit(10000)
       .setIterationWaitTime(20000)

--- a/src/test/scala/eu/proteus/solma/obsg_svm/OBSG_SVMITSuite.scala
+++ b/src/test/scala/eu/proteus/solma/obsg_svm/OBSG_SVMITSuite.scala
@@ -132,7 +132,7 @@ object OBSG_SVMITSuite {
     env.setParallelism(4)
 
     val obsg_svm = OBSG_SVM()
-      .setCParam(0.35)
+      .setCParam(0.001)
       .setFeaturesCount(8)
       .setPullLimit(10000)
       .setIterationWaitTime(20000)

--- a/src/test/scala/eu/proteus/solma/obsg_svm/OBSG_SVMITSuite.scala
+++ b/src/test/scala/eu/proteus/solma/obsg_svm/OBSG_SVMITSuite.scala
@@ -132,7 +132,7 @@ object OBSG_SVMITSuite {
     env.setParallelism(4)
 
     val obsg_svm = OBSG_SVM()
-      .setCParam(0.001)
+      .setCParam(1)
       .setFeaturesCount(8)
       .setPullLimit(10000)
       .setIterationWaitTime(20000)

--- a/src/test/scala/eu/proteus/solma/obsg_svm/OBSG_SVMITSuite.scala
+++ b/src/test/scala/eu/proteus/solma/obsg_svm/OBSG_SVMITSuite.scala
@@ -176,7 +176,8 @@ object OBSG_SVMITSuite {
         }
 
         override def flatMap1(
-                               value: Either[(Long, UnlabeledVector, Double), (Int, (linalg.DenseVector[Double], Double))],
+                               value: Either[(Long, UnlabeledVector, Double),
+                                 (Int, (linalg.DenseVector[Double], Double))],
                                out: Collector[BinaryConfusionMatrix]
                              ): Unit = {
           value match {


### PR DESCRIPTION
This PR introduces Online Bilevel Stochastic Gradient SVM for binary classification. The implementation is based on the parameter server. It uses the OSVM template. A minimal test is available.